### PR TITLE
Fix type errors

### DIFF
--- a/components/logon.js
+++ b/components/logon.js
@@ -154,7 +154,10 @@ function onConnected() {
 }
 
 SteamGameServer.prototype.logOff = SteamGameServer.prototype.disconnect = function(suppressLogoff) {
-	this.client.removeListener('connected', this._onConnected);
+	if (this._onConnected) {
+		this.client.removeListener('connected', this._onConnected);
+		this._onConnected = null;
+	}
 
 	if (this.client.connected && !suppressLogoff) {
 		this._loggingOff = true;
@@ -219,7 +222,7 @@ SteamGameServer.prototype._handlers[SteamGameServer.EMsg.ClientLogOnResponse] = 
 			this.publicIP = Helpers.ipIntToString(body.public_ip);
 			this.cellID = body.cell_id;
 
-			this.storage.saveFile('cellid-' + Helpers.getInternalMachineID() + '.txt', body.cell_id);
+			this.storage.saveFile('cellid-' + Helpers.getInternalMachineID() + '.txt', body.cell_id.toString());
 
 			// Send the GS info
 			this._send(SteamGameServer.EMsg.GSServerType, {


### PR DESCRIPTION
Hello there! I found your package and I am using it to fetch server lists. It seems to be working great even though it hasn't been updated in a while 👍

I had to make two changes to make it work with modern Node, though, and they're both because of type errors.

`storage.saveFile` expects a string, but you're giving it a number. This change converts `body.cell_id` to a string.
`EventEmitter::removeListener` expects a function, but `this._onConnected` will sometimes be `undefined`. We can check the value of `this._onConnected` before trying to remove it as a listener.
